### PR TITLE
Add a Go import comment.

### DIFF
--- a/pqueue.go
+++ b/pqueue.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package pqueue
+package pqueue // import "sevki.org/pqueue"
 
 import (
 	"container/heap"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
